### PR TITLE
Project: Add surrogate `setup.py` to satisfy GitHub

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+# This is a shim to allow GitHub to decode the package in order to provide
+# the "Used by" section on the project homepage.
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup(name="mlflow-cratedb")


### PR DESCRIPTION
A surrogate `setup.py` is needed to enable the "Used by" section on GitHub. GitHub apparently still can't decode projects exclusively using `pyproject.toml` files in 2024.
