### PR TITLE
Use SQLAlchemy patches and polyfills from `sqlalchemy-cratedb`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## in progress
+- Started using more SQLAlchemy patches and polyfills from `sqlalchemy-cratedb`
 
 ## 2024-06-18 v2.14.0
 - Remove patch for SQLAlchemy Inspector's `get_table_names`.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -53,3 +53,4 @@
   see, for example, tracking_dummy.py#L53-L55.
   Alternatively, find an "autoload" solution for Python?
 - Code: Refactor / break out the generic SQLALchemy polyfill patches into `cratedb-toolkit`
+- Code: Refactor SQLALchemy polyfills and patches into `sqlalchemy-cratedb`

--- a/mlflow_cratedb/patch/mlflow/model.py
+++ b/mlflow_cratedb/patch/mlflow/model.py
@@ -1,6 +1,6 @@
 import sqlalchemy as sa
-from cratedb_toolkit.sqlalchemy import check_uniqueness_factory
 from sqlalchemy.event import listen
+from sqlalchemy_cratedb.support import check_uniqueness_factory
 
 
 def polyfill_uniqueness_constraints():

--- a/mlflow_cratedb/patch/sqlalchemy.py
+++ b/mlflow_cratedb/patch/sqlalchemy.py
@@ -1,4 +1,4 @@
 def patch_sqlalchemy():
-    from cratedb_toolkit.sqlalchemy import polyfill_autoincrement
+    from sqlalchemy_cratedb.support import patch_autoincrement_timestamp
 
-    polyfill_autoincrement()
+    patch_autoincrement_timestamp()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,11 +77,10 @@ dynamic = [
 
 dependencies = [
   "crash",
-  "cratedb-toolkit>=0.0.13,<0.1",
   "dask>=2024.4.1",
   "joblib!=1.4.0,<1.5",
   "mlflow==2.14.0",
-  "sqlalchemy-cratedb>=0.37,<1",
+  "sqlalchemy-cratedb>=0.38.0,<1",
   "sqlparse<0.6",
 ]
 


### PR DESCRIPTION
## About
In order to trim dependencies, this patch validates a few details without installing the [cratedb-toolkit](https://github.com/crate-workbench/cratedb-toolkit) package, or otherwise depending on it. Instead, it uses the new [sqlalchemy-cratedb](https://github.com/crate/sqlalchemy-cratedb) package.

## References
- https://github.com/crate/cratedb-examples/pull/498