### PR TITLE
OCI: Fix segfaults on ARM builds

### DIFF
--- a/.github/workflows/oci-runtime.yml
+++ b/.github/workflows/oci-runtime.yml
@@ -67,6 +67,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/oci-server.yml
+++ b/.github/workflows/oci-server.yml
@@ -105,6 +105,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
 
       - name: Set up Docker Buildx
         id: buildx


### PR DESCRIPTION
## Problem
OCI builds on ARM started failing the other day.
```
131.0 Processing triggers for libc-bin (2.31-13+deb11u11) ...
131.1 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
131.4 Segmentation fault (core dumped)
```


## References
- https://github.com/crate/mlflow-cratedb/issues/208